### PR TITLE
allow localhost for cron tasks

### DIFF
--- a/mod_cloudflare.c
+++ b/mod_cloudflare.c
@@ -57,12 +57,14 @@ static const char* CF_DEFAULT_TRUSTED_PROXY[] = {
   "162.158.0.0/15",
   "104.16.0.0/12",
   "172.64.0.0/13",
+  "127.0.0.1/32",  // localhost IPv4
 /* IPv6 Address Ranges */
   "2400:cb00::/32",
   "2606:4700::/32",
   "2803:f800::/32",
   "2405:b500::/32",
   "2405:8100::/32",
+  "::1/64",   // localhost IPv6
 };
 static const size_t CF_DEFAULT_TRUSTED_PROXY_COUNT = 
   sizeof(CF_DEFAULT_TRUSTED_PROXY)/sizeof(char *);


### PR DESCRIPTION
It's quite common to have a cron task running on the webserver to trigger database cleanup tasks. By adding localhost (127.0.0.1 and ::1) to the allowed proxy list, we can use cron tasks aimed at localhost instead of making the external long-way-around-the-world request out to Cloudflare and then back into our web server.