### PR TITLE
Add deny_all flag to merge config. Fixes issue with persistent 403 from non-CF clients.

### DIFF
--- a/mod_cloudflare.c
+++ b/mod_cloudflare.c
@@ -143,6 +143,7 @@ static void *merge_cloudflare_server_config(apr_pool_t *p, void *globalv,
     config->proxymatch_ip = server->proxymatch_ip
                           ? server->proxymatch_ip
                           : global->proxymatch_ip;
+    config->deny_all = (server->deny_all || global->deny_all);
     return config;
 }
 


### PR DESCRIPTION
Fixes issues when setting overriding CloudFlareRemoteIPTrustedProxy; Apache always returns a 403 from non-CF IP's even though DenyAllButCloudFlare disabled.