### PR TITLE
Fix compile warning (incompatible pointer type)

### DIFF
--- a/mod_cloudflare.c
+++ b/mod_cloudflare.c
@@ -183,10 +183,9 @@ static apr_status_t set_cf_default_proxies(apr_pool_t *p, cloudflare_config_t *c
      apr_status_t rv;
      cloudflare_proxymatch_t *match;
      int i;
-     char **proxies = CF_DEFAULT_TRUSTED_PROXY;
 
      for (i=0; i<CF_DEFAULT_TRUSTED_PROXY_COUNT; i++) {
-         char *ip = apr_pstrdup(p, proxies[i]);
+         char *ip = apr_pstrdup(p, CF_DEFAULT_TRUSTED_PROXY[i]);
          char *s = ap_strchr(ip, '/');
 
          if (s) {


### PR DESCRIPTION
mod_cloudflare.c: In function 'set_cf_default_proxies':
mod_cloudflare.c:187:23: warning: initialization from incompatible
pointer type [enabled by default]
      char **proxies = CF_DEFAULT_TRUSTED_PROXY;
                       ^

The above error was being emitted on gcc 4.8.5 (apache 2.4.6) before applying this change. Verified things still seem to function as far as access_logs go.