### PR TITLE
More accurate EA3/EA4 detection

### DIFF
--- a/EasyApache/installer.sh
+++ b/EasyApache/installer.sh
@@ -95,13 +95,8 @@ function install_ea4 {
 # Main
 #
 
-#
-# Check which version of cPanel we have
-#
-CPANEL_VERSION=`/usr/local/cpanel/cpanel -V | sed "s/\..*$//"`
-
-# Version 58 and up have Easy Apache 4
-if [ "$CPANEL_VERSION" -gt "57" ]; then
+# Check if Easy Apache 4 is enabled
+if [ -e "/etc/cpanel/ea4/is_ea4" ]; then
    install_ea4
 else
    install_ea3

--- a/EasyApache/installer.sh
+++ b/EasyApache/installer.sh
@@ -95,7 +95,7 @@ function install_ea4 {
 # Main
 #
 
-# Check if Easy Apache 4 is enabled
+# Check if EasyApache 4 is enabled
 if [ -e "/etc/cpanel/ea4/is_ea4" ]; then
    install_ea4
 else


### PR DESCRIPTION
cPanel servers don't automatically switch to EasyApache 4 when they're updated to the version the script checks. The official way to check if the server is running EA3 or EA4 is to check if the file /etc/cpanel/ea4/is_ea4 exists. EasyApache 3 itself actually checks if the file exists, and if it does, it exits:

```
stat("/etc/cpanel/ea4/is_ea4", {st_mode=S_IFREG|0644, st_size=0, ...}) = 0
write(2, "EasyApache3 is not available whe"..., 60EasyApache3 is not available when EasyApache4 is in effect.
```