### PR TITLE
Add CLOUDFLARE_CONNECTION env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ To use it (replacing the original mode if you already use it), simply clone it a
     apxs2 -a -i -c mod_cloudflare.c
     service apache2 restart
 
+CloudFlare is welcome to implement this in their official repo :)
+
 
 ## mod_cloudflare.c ##
 
@@ -35,6 +37,7 @@ An alternative way to install is to use GNU autotools, which requires that autoc
     
 ### OS Support ###
 
+- Debian/Ubuntu - Supported
 - CentOS - Supported
 - CloudLinux - Not Supported
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
 # mod_cloudflare for Apache #
 Copyright CloudFlare Inc. 2016
 
+Modded by p0358
+
+## FORK INFO ##
+
+This fork adds `CLOUDFLARE_CONNECTION` env variable set to "true" if connection originated from one of module's trusted proxy IPs. It is very useful since you cannot add `DenyAllButCloudflare` directive everywhere, but instead you can now use `Require env CLOUDFLARE_CONNECTION` or `Require expr "-T env('CLOUDFLARE_CONNECTION')"` (the latter example provided if you want to mix it with other expressions, you could also consider the first one inside `RequireAll` block instead).
+
+To use it (replacing the original mode if you already use it), simply clone it and use instructions from below. On Ubuntu/Debian you can just execute:
+
+    git clone https://github.com/p0358/mod_cloudflare.git
+    cd mod_cloudflare
+    apt install apache2-dev
+    apxs2 -a -i -c mod_cloudflare.c
+    service apache2 restart
+
+
 ## mod_cloudflare.c ##
 
 Based on mod_remoteip.c, this Apache extension will replace the remote_ip variable in user's logs with the correct remote IP sent from CloudFlare. The module only performs the IP substitution for requests originating from CloudFlare IPs by default.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Modded by p0358
 
 This fork adds `CLOUDFLARE_CONNECTION` env variable set to "true" if connection originated from one of module's trusted proxy IPs. It is very useful since you cannot add `DenyAllButCloudflare` directive everywhere, but instead you can now use `Require env CLOUDFLARE_CONNECTION` or `Require expr "-T env('CLOUDFLARE_CONNECTION')"` (the latter example provided if you want to mix it with other expressions, you could also consider the first one inside `RequireAll` block instead).
 
-To use it (replacing the original mode if you already use it), simply clone it and use instructions from below. On Ubuntu/Debian you can just execute:
+To use it (replacing the original mode if you already use it), simply clone it and use install instructions from below. Or on Ubuntu/Debian you can just execute:
 
     git clone https://github.com/p0358/mod_cloudflare.git
     cd mod_cloudflare

--- a/mod_cloudflare.c
+++ b/mod_cloudflare.c
@@ -282,11 +282,12 @@ static int cloudflare_modify_connection(request_rec *r)
     const char *cf_visitor_header = NULL;
 
     apr_pool_userdata_get((void*)&conn, "mod_cloudflare-conn", c->pool);
+  
+    apr_table_t *e = r->subprocess_env;
 
     cf_visitor_header = apr_table_get(r->headers_in, "CF-Visitor");
     if (cf_visitor_header != NULL) {
         if ((remote) && (strstr(cf_visitor_header, "https") != NULL)) {
-            apr_table_t *e = r->subprocess_env;
             apr_table_addn(e, "HTTPS", "on");
         }
     }
@@ -371,6 +372,8 @@ static int cloudflare_modify_connection(request_rec *r)
                 } else {
                     break;
                 }
+            } else {
+                apr_table_addn(e, "CLOUDFLARE_CONNECTION", "true"); 
             }
         }
 


### PR DESCRIPTION
What can this be used for is described in fork's README file.

 If this feature was appreciated, I'd adjust the readme file to match this repo (that is remove "Modded by p0358", "FORK INFO", and add the info about new feature somewhere).